### PR TITLE
Babashka compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,24 @@ jobs:
           paths:
             - ~/.m2
 
+  test-bb:
+    executor: clojure
+    steps:
+      - run:
+          name: Install babashka
+          command: |
+            sudo bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-test-cljs-{{ checksum "project.clj" }}
+            - v1-test-cljs-
+      - run: bb test:bb
+      - save_cache:
+          key: v1-test-cljs-{{ checksum "project.clj" }}
+          paths:
+            - ~/.m2
+
   coverage:
     executor: clojure
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
             - v1-test-bb-
       - run: bb test:bb
       - save_cache:
-          key: v1-test-cljs-{{ checksum "project.clj" }}
+          key: v1-test-bb-{{ checksum "project.clj" }}
           paths:
             - ~/.m2
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,8 +90,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-test-cljs-{{ checksum "project.clj" }}
-            - v1-test-cljs-
+            - v1-test-bb-{{ checksum "project.clj" }}
+            - v1-test-bb-
       - run: bb test:bb
       - save_cache:
           key: v1-test-cljs-{{ checksum "project.clj" }}

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,9 @@
+{:deps {mvxcvi/multiformats {:local/root "."}}
+ :tasks
+ {test:bb {:extra-paths ["test"]
+           :extra-deps {io.github.cognitect-labs/test-runner
+                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+           :requires ([cognitect.test-runner])
+           :task (apply cognitect.test-runner/-main
+                        "--namespace" "multiformats.hash-test"
+                        *command-line-args*)}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src" "resources"],
+ :deps
+ {mvxcvi/alphabase {:mvn/version "2.1.0"},
+  commons-codec/commons-codec {:mvn/version "1.14"}}}

--- a/src/multiformats/base/b16.cljc
+++ b/src/multiformats/base/b16.cljc
@@ -5,6 +5,7 @@
     [alphabase.bytes :as b]
     [alphabase.hex :as hex]))
 
+
 (defn byte->hex
   "Converts a single byte value to a two-character hex string."
   [value]
@@ -14,6 +15,7 @@
       (str "0" hex)
       hex)))
 
+
 (defn format-slice
   "Format a slice of a byte array as a hex string."
   [data offset length]
@@ -21,11 +23,13 @@
        (map #(byte->hex (b/get-byte data %)))
        (apply str)))
 
+
 (defn format
   "Format byte data as a hexadecimal-encoded string."
   ^String
   [^bytes data]
   (hex/encode data))
+
 
 (defn parse
   "Parse a hexadecimal-encoded string into bytes."

--- a/src/multiformats/base/b16.cljc
+++ b/src/multiformats/base/b16.cljc
@@ -2,13 +2,8 @@
   "Hexadecimal base encoding implementation."
   (:refer-clojure :exclude [format])
   (:require
-    [alphabase.bytes :as b]
-    #?(:cljs [goog.crypt :as crypt]))
-  #?(:clj
-     (:import
-       (org.apache.commons.codec.binary
-         Hex))))
-
+   [alphabase.bytes :as b]
+   [alphabase.hex :as hex]))
 
 (defn byte->hex
   "Converts a single byte value to a two-character hex string."
@@ -19,7 +14,6 @@
       (str "0" hex)
       hex)))
 
-
 (defn format-slice
   "Format a slice of a byte array as a hex string."
   [data offset length]
@@ -27,16 +21,13 @@
        (map #(byte->hex (b/get-byte data %)))
        (apply str)))
 
-
 (defn format
   "Format byte data as a hexadecimal-encoded string."
+  ^String
   [^bytes data]
-  #?(:clj (Hex/encodeHexString data true)
-     :cljs (crypt/byteArrayToHex data)))
-
+  (hex/encode data))
 
 (defn parse
   "Parse a hexadecimal-encoded string into bytes."
   [^String string]
-  #?(:clj (Hex/decodeHex string)
-     :cljs (crypt/hexToByteArray string)))
+  (hex/decode string))

--- a/src/multiformats/base/b16.cljc
+++ b/src/multiformats/base/b16.cljc
@@ -2,8 +2,8 @@
   "Hexadecimal base encoding implementation."
   (:refer-clojure :exclude [format])
   (:require
-   [alphabase.bytes :as b]
-   [alphabase.hex :as hex]))
+    [alphabase.bytes :as b]
+    [alphabase.hex :as hex]))
 
 (defn byte->hex
   "Converts a single byte value to a two-character hex string."

--- a/src/multiformats/hash.cljc
+++ b/src/multiformats/hash.cljc
@@ -6,8 +6,8 @@
   https://github.com/multiformats/multihash"
   (:refer-clojure :exclude [test])
   (:require
-   [alphabase.bytes :as b]
-   #?@(:cljs
+    [alphabase.bytes :as b]
+    #?@(:cljs
         [[goog.crypt :as crypt]
          [goog.crypt.Md5]
          [goog.crypt.Sha1]
@@ -103,35 +103,40 @@
 ;; ## Multihash Type
 #?(:bb
    (do
-     (defn length [mhash]
+     (defn length
+       [mhash]
        (count (:_bytes mhash)))
 
-     (defn digest [mhash]
+     (defn digest
+       [mhash]
        (:digest (decode-parameters (:_bytes mhash))))
 
-     (defn code [mhash]
+     (defn code
+       [mhash]
        (first (read-header (:_bytes mhash))))
 
-     (defn algorithm [mhash]
+     (defn algorithm
+       [mhash]
        (let [[code] (read-header (:_bytes mhash))]
          (find-algorithm code)))
 
-     (defn bits [mhash]
+     (defn bits
+       [mhash]
        (let [[_ length] (read-header (:_bytes mhash))]
          (* length 8)))))
 
 #?(:bb
    (defrecord Multihash
-       [_bytes _meta _hash]
+     [_bytes _meta _hash]
      Object
      (toString
        [this]
        (str "hash:" (name (algorithm this)) \: (digest this))))
    :default
    (deftype Multihash
-       [^bytes _bytes
-        _meta
-        ^:unsynchronized-mutable _hash]
+     [^bytes _bytes
+      _meta
+      ^:unsynchronized-mutable _hash]
 
      Object
 
@@ -185,9 +190,9 @@
 
          :else
          (throw (ex-info
-                 (str "Cannot compare multihash value to " (type that))
-                 {:this this
-                  :that that}))))
+                  (str "Cannot compare multihash value to " (type that))
+                  {:this this
+                   :that that}))))
 
 
      ILookup
@@ -438,8 +443,8 @@
                     (multiformats.hash/digest other))
              :default (= mhash other)))
         (throw (ex-info
-                (str "No supported hashing function for algorithm "
-                     (or (algo mhash) (:code mhash))
-                     " to validate " mhash)
-                {:code (:code mhash)
-                 :algorithm (algo mhash)}))))))
+                 (str "No supported hashing function for algorithm "
+                      (or (algo mhash) (:code mhash))
+                      " to validate " mhash)
+                 {:code (:code mhash)
+                  :algorithm (algo mhash)}))))))

--- a/src/multiformats/hash.cljc
+++ b/src/multiformats/hash.cljc
@@ -125,6 +125,7 @@
        (let [[_ length] (read-header (:_bytes mhash))]
          (* length 8)))))
 
+
 #?(:bb
    (defrecord Multihash
      [_bytes _meta _hash]

--- a/test/multiformats/hash_test.cljc
+++ b/test/multiformats/hash_test.cljc
@@ -29,6 +29,7 @@
         (mhash/create 0x11 (b/byte-array 0)))
       "Empty digest should be rejected"))
 
+
 #?(:bb nil :default
    (deftest value-semantics
      (let [a (mhash/create 0x11 "0beec7b8")
@@ -77,11 +78,13 @@
    "22040006b46b"
    [0x22 :murmur3 32 "0006b46b"]})
 
+
 (def length #?(:bb mhash/length :default :length))
 (def code* #?(:bb mhash/code :default :code))
 (def algorithm* #?(:bb mhash/algorithm :default :algorithm))
 (def digest* #?(:bb mhash/digest :default :digest))
 (def bits* #?(:bb mhash/bits :default :bits))
+
 
 (deftest example-coding
   (testing "Encoding is reflexive"

--- a/test/multiformats/hash_test.cljc
+++ b/test/multiformats/hash_test.cljc
@@ -79,33 +79,26 @@
    [0x22 :murmur3 32 "0006b46b"]})
 
 
-(def length #?(:bb mhash/length :default :length))
-(def code* #?(:bb mhash/code :default :code))
-(def algorithm* #?(:bb mhash/algorithm :default :algorithm))
-(def digest* #?(:bb mhash/digest :default :digest))
-(def bits* #?(:bb mhash/bits :default :bits))
-
-
 (deftest example-coding
   (testing "Encoding is reflexive"
     (let [mhash (mhash/create 0x02 "0beec7b8")
           encoded (mhash/encode mhash)]
-      (is (= 6 (length mhash) (alength encoded)))
+      (is (= 6 (:length mhash) (alength encoded)))
       #?(:bb nil
          :default (is (= mhash (mhash/decode encoded))))))
   (testing "buffer writes"
     (let [mhash (mhash/create :sha1 "deadbeef")
-          buffer (b/byte-array (+ 4 (length mhash)))]
+          buffer (b/byte-array (+ 4 (:length mhash)))]
       (is (= 6 (mhash/write-bytes mhash buffer 2)))
       (is (bytes= (b/init-bytes [0x00 0x00 0x11 0x04 0xde 0xad 0xbe 0xef 0x00 0x00])
                   buffer))))
   (doseq [[hex [code algorithm bits digest]] examples]
     (let [mhash (mhash/create algorithm digest)]
-      (is (= (/ (count hex) 2) (length mhash)))
-      (is (= code (code* mhash)))
-      (is (= algorithm (algorithm* mhash)))
-      (is (= bits (bits* mhash)))
-      (is (= digest (digest* mhash)))
+      (is (= (/ (count hex) 2) (:length mhash)))
+      (is (= code (:code mhash)))
+      (is (= algorithm (:algorithm mhash)))
+      (is (= bits (:bits mhash)))
+      (is (= digest (:digest mhash)))
       (is (= hex (mhash/hex mhash))
           "Encoded multihashes match expected hex")
       #?(:bb nil
@@ -127,15 +120,15 @@
             mh4 #?(:clj (hash-fn (ByteArrayInputStream. (.getBytes content)))
                    :cljs mh1)]
         (is (= algorithm
-               (algorithm* mh1)
-               (algorithm* mh2)
-               (algorithm* mh3)
-               (algorithm* mh4))
+               (:algorithm mh1)
+               (:algorithm mh2)
+               (:algorithm mh3)
+               (:algorithm mh4))
             "Constructed multihash algorithms match")
-        (is (= (digest* mh1)
-               (digest* mh2)
-               (digest* mh3)
-               (digest* mh4))
+        (is (= (:digest mh1)
+               (:digest mh2)
+               (:digest mh3)
+               (:digest mh4))
             "Constructed multihash digests match")
         (is (thrown? #?(:clj Exception, :cljs js/Error)
               (hash-fn 123)))))))


### PR DESCRIPTION
This is a similar PR to https://github.com/multiformats/clj-multihash/pull/15

We're using this library extensively at Nextjournal and also use it in the context of babashka scripts. We can use our own fork, but it would be great if it can be merged upstream.

The only namespace that was made compatible is `multiformats.hash`.

cc @greglook 