### PR TITLE
Restore compatibility with bb 1.12.194

### DIFF
--- a/src/multiformats/hash.cljc
+++ b/src/multiformats/hash.cljc
@@ -111,7 +111,7 @@
 
 #?(:bb
    (defrecord Multihash
-     [_bytes]
+     [_bytes _meta _hash]
 
      Object
 


### PR DESCRIPTION
bb 1.12.194 became more strict about the number of arguments passed to a `->Record` constructor function (conform how Clojure works). This PR fixes that compatibility issue.